### PR TITLE
自動ビルド用ワークフロー追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
     strategy:
       matrix:
         standalone: [ true, false ]
+        # 接続先をProdにしたバージョンを作成する場合は、リストにfalseを追加する
+        dev: [ true ]
     steps:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
@@ -54,7 +56,12 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs
         run: |
-          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${{ secrets.SERVER_ADDRESS }}\"; }" > ./ServerAddress.cs
+          if [ "${{ matrix.dev }}" = "true" ]; then
+            SERVER_ADDRESS=${{ secrets.SERVER_ADDRESS_DEV }}
+          else
+            SERVER_ADDRESS=${{ secrets.SERVER_ADDRESS }}
+          fi
+          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${SERVER_ADDRESS}\"; }" > ./ServerAddress.cs
       - name: Setup dotnet 8.0.x
         uses: actions/setup-dotnet@v4.3.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: Build
+on:
+  push: {}
+  
+env:
+  APP_NAME: "TraincrewTIDWindow"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Build"
+    strategy:
+      matrix:
+        standalone: [ true, false ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup dotnet 8.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build Exe
+        run: |
+          dotnet publish -c Release \
+            -o ../out \
+            -r win-x64 \
+            -p:PublishSingleFile=true \
+            -p:EnableWindowsTargeting=true \
+            --self-contained ${{ matrix.standalone }}
+      - name: Zip binaries
+        run: |
+          cd out
+          zip -r ../out.zip .
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          path: 'out.zip'
+          name: ${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip
+  create_new_release:
+    runs-on: ubuntu-latest
+    name: "Create New Release"
+    needs: build
+    # mainブランチにpushした場合のみ、このワークフローを作動させる
+    # if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const response = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            return response.data.tag_name;
+      - name: Bump patch version
+        id: bump_version
+        run: |
+          version=$(echo ${{ steps.latest_release.outputs.result }} | awk -F. '{$3+=1; OFS="."; print $1,$2,$3}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          path: 'out'
+          merge-multiple: 'true'
+      - name: Create New Release
+        id: create_release
+        uses: softprops/action-gh-release@v2.2.1
+        with:
+          tag_name: ${{ steps.bump_version.outputs.version }}
+          name: Release ${{ steps.bump_version.outputs.version }}
+          files: out/* 
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Write ServerAddress.cs
+        run: |
+          echo "namespace TraincrewTIDWindow; { public static class ServerAddress { public const string Address = \"${{ secrets.SERVER_ADDRESS }}\"; } }" > ./ServerAddress.cs
       - name: Setup dotnet 8.0.x
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ on:
   push: {}
   
 env:
-  APP_NAME: "TraincrewTIDWindow"
-  NAMESPACE: "TraincrewTIDWindow"
+  APP_NAME: "TrainCrewTIDWindow"
+  NAMESPACE: "TrainCrewTIDWindow"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Write ServerAddress.cs
         run: |
-          echo "namespace TraincrewTIDWindow; { public static class ServerAddress { public const string Address = \"${{ secrets.SERVER_ADDRESS }}\"; } }" > ./ServerAddress.cs
+          echo "namespace TraincrewTIDWindow; public static class ServerAddress { public const string SignalAddress = \"${{ secrets.SERVER_ADDRESS }}\"; }" > ./ServerAddress.cs
       - name: Setup dotnet 8.0.x
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Calculate Version
         id: calc_version
         run: |
-          latest_tag=${{ steps.latest_release.outputs.result }}
+          latest_tag="${{ steps.latest_release.outputs.result }}"
           if [ -n "${latest_tag}" ]; then
             today=$(date +%Y%m%d)
             if [[ $latest_tag == $today* ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Zip binaries
         run: |
           cd out
-          zip -r ../${{ env.FILE_NAME }} .
+          zip -r ../${{ env.ZIP_FILE_NAME }} .
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.6.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,20 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           script: |
-            const response = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            return response.data.tag_name;
+            try {
+              const response = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              return response.data.tag_name;
+            }
+            catch (e){
+              if (e.status === 404) {
+                return '';
+              } else {
+                throw e;
+              }
+            }
       - name: Calculate Version
         id: calc_version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
-        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.standalone && '-standalone') || '' }}${{ (matrix.dev && '-dev') || ''}}.zip" >> $GITHUB_ENV
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   
 env:
   APP_NAME: "TraincrewTIDWindow"
+  NAMESPACE: "TraincrewTIDWindow"
 
 jobs:
   build:
@@ -17,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Write ServerAddress.cs
         run: |
-          echo "namespace TraincrewTIDWindow; public static class ServerAddress { public const string SignalAddress = \"${{ secrets.SERVER_ADDRESS }}\"; }" > ./ServerAddress.cs
+          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${{ secrets.SERVER_ADDRESS }}\"; }" > ./ServerAddress.cs
       - name: Setup dotnet 8.0.x
         uses: actions/setup-dotnet@v3
         with:
@@ -25,7 +26,7 @@ jobs:
       - name: Build Exe
         run: |
           dotnet publish -c Release \
-            -o ../out \
+            -o ./out \
             -r win-x64 \
             -p:PublishSingleFile=true \
             -p:EnableWindowsTargeting=true \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   calc_version:
     runs-on: ubuntu-latest
     name: "Calc Version"
+    outputs:
+      VERSION: ${{ steps.calc_version.outputs.VERSION }}
     steps:
       - name: Get latest release
         id: latest_release
@@ -38,7 +40,7 @@ jobs:
           else
             VERSION=$(date +%Y%m%d%H%M%S)
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
   build:
     runs-on: ubuntu-latest
     name: "Build"
@@ -51,7 +53,7 @@ jobs:
     steps:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
-        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}_${{ env.VERSION }}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}_${{ needs.calc_version.outputs.VERSION }}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs
@@ -86,7 +88,9 @@ jobs:
   create_new_release:
     runs-on: ubuntu-latest
     name: "Create New Release"
-    needs: build
+    needs:
+      - calc_version
+      - build
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4.2.1
@@ -100,4 +104,3 @@ jobs:
           tag_name: ${{ needs.calc_version.outputs.VERSION }}
           make_latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           files: out/* 
-          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          path: ${{ env.ZIP_FILE_NAME }}
-          name: ${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip
+          path: ./${{ env.ZIP_FILE_NAME }}
+          name: ${{ env.ZIP_FILE_NAME }}
   create_new_release:
     runs-on: ubuntu-latest
     name: "Create New Release"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,55 @@
 name: Build
 on:
-  push: {}
-  
+  push: { }
+
 env:
   APP_NAME: "TrainCrewTIDWindow"
   NAMESPACE: "TrainCrewTIDWindow"
 
 jobs:
+  calc_version:
+    runs-on: ubuntu-latest
+    name: "Calc Version"
+    steps:
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v7.0.1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          script: |
+            const response = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            return response.data.tag_name;
+      - name: Calculate Version
+        id: calc_version
+        run: |
+          latest_tag=${{ steps.latest_release.outputs.result }}
+          if [ -n "${latest_tag}" ]; then
+            today=$(date +%Y%m%d)
+            if [[ $latest_tag == $today* ]]; then
+              n=$(echo $latest_tag | awk -F_ '{print $2}')
+              n=$((n + 1))
+            else
+              n=1
+            fi
+            VERSION="${today}_${n}"
+          else
+            VERSION=$(date +%Y%m%d%H%M%S)
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
   build:
     runs-on: ubuntu-latest
     name: "Build"
+    needs: calc_version
     strategy:
       matrix:
         standalone: [ true, false ]
     steps:
       - name: Set Zip File Name
-        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
+        # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.standalone && '-standalone') || '' }}${{ (matrix.dev && '-dev') || ''}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs
@@ -46,24 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Create New Release"
     needs: build
-    # mainブランチにpushした場合のみ、このワークフローを作動させる
-    # if: github.ref == 'refs/heads/main'
     steps:
-      - name: Get latest release
-        id: latest_release
-        uses: actions/github-script@v7.0.1
-        with:
-          script: |
-            const response = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            return response.data.tag_name;
-      - name: Bump patch version
-        id: bump_version
-        run: |
-          version=$(echo ${{ steps.latest_release.outputs.result }} | awk -F. '{$3+=1; OFS="."; print $1,$2,$3}')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Download Artifact
         uses: actions/download-artifact@v4.2.1
         with:
@@ -73,7 +90,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2.2.1
         with:
-          tag_name: ${{ steps.bump_version.outputs.version }}
-          name: Release ${{ steps.bump_version.outputs.version }}
+          tag_name: ${{ needs.calc_version.outputs.VERSION }}
+          make_latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           files: out/* 
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         standalone: [ true, false ]
     steps:
+      - name: Set Zip File Name
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - name: Write ServerAddress.cs
@@ -34,11 +36,11 @@ jobs:
       - name: Zip binaries
         run: |
           cd out
-          zip -r ../out.zip .
+          zip -r ../${{ env.FILE_NAME }} .
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          path: 'out.zip'
+          path: ${{ env.ZIP_FILE_NAME }}
           name: ${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip
   create_new_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
-        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.standalone && '-standalone') || '' }}${{ (matrix.dev && '-dev') || ''}.zip" >> $GITHUB_ENV
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.standalone && '-standalone') || '' }}${{ (matrix.dev && '-dev') || ''}}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
       - name: List downloaded files
         id: list_files
         run: |
+          ls out
           files=$(ls out)
           files_json=$(echo "$files" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "files=${files_json}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
   create_new_release:
     runs-on: ubuntu-latest
     name: "Create New Release"
+    permissions:
+      contents: write
     needs:
       - calc_version
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,18 +69,11 @@ jobs:
         with:
           path: 'out'
           merge-multiple: 'true'
-      - name: List downloaded files
-        id: list_files
-        run: |
-          ls out
-          files=$(ls out)
-          files_json=$(echo "$files" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "files=${files_json}" >> "$GITHUB_OUTPUT"
       - name: Create New Release
         id: create_release
         uses: softprops/action-gh-release@v2.2.1
         with:
           tag_name: ${{ steps.bump_version.outputs.version }}
           name: Release ${{ steps.bump_version.outputs.version }}
-          files: ${{ steps.list_files.outputs.files }}
+          files: out/* 
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Set Zip File Name
         run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs
         run: |
           echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${{ secrets.SERVER_ADDRESS }}\"; }" > ./ServerAddress.cs
       - name: Setup dotnet 8.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: '8.0.x'
       - name: Build Exe
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Get latest release
         id: latest_release
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             const response = await github.rest.repos.getLatestRelease({

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,11 +67,17 @@ jobs:
         with:
           path: 'out'
           merge-multiple: 'true'
+      - name: List downloaded files
+        id: list_files
+        run: |
+          files=$(ls out)
+          files_json=$(echo "$files" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "files=${files_json}" >> "$GITHUB_OUTPUT"
       - name: Create New Release
         id: create_release
         uses: softprops/action-gh-release@v2.2.1
         with:
           tag_name: ${{ steps.bump_version.outputs.version }}
           name: Release ${{ steps.bump_version.outputs.version }}
-          files: out/* 
+          files: ${{ steps.list_files.outputs.files }}
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
 env:
   APP_NAME: ${{ github.event.repository.name }}
   NAMESPACE: "TrainCrewTIDWindow"
+  TZ: "Asia/Tokyo"
 
 jobs:
   calc_version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push: { }
 
 env:
-  APP_NAME: "TrainCrewTIDWindow"
+  APP_NAME: ${{ github.event.repository.name }}
   NAMESPACE: "TrainCrewTIDWindow"
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
-        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}}_${{ env.VERSION }}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
+        run: echo "ZIP_FILE_NAME=${{ env.APP_NAME }}_${{ env.VERSION }}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Write ServerAddress.cs

--- a/TrainCrewTIDWindow.csproj
+++ b/TrainCrewTIDWindow.csproj
@@ -46,5 +46,13 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="png\**\*">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Update="setting\**\*">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# 仕様
mainにPushした場合、以下のようにYYYYmmdd_nで、latest_releaseでリリースされる
https://github.com/Kesigomon/TrainCrewTIDWindow/releases/tag/20250408_1

main以外にPushした場合、以下のようにYYYYmmddHHMMSS 形式でリリースされる(latest_releaseにはならない)
https://github.com/Kesigomon/TrainCrewTIDWindow/releases/tag/20250407204120

`-dev` が dev環境アドレスのバイナリ(ついてないのはProd環境へのバイナリ)、`-standalone` は .NET Core 8.0 Runtimeなしでも動くバージョン(逆に、ついてないバージョンは .NET Core 8.0 Runtimeが必要になる)

# 必須シークレット
`SERVER_ADDRESS_DEV` => Dev環境のサーバーアドレス
`SERVER_ADDRESS` => Prod環境のサーバーアドレス


設定方法は以下参照
https://docs.github.com/ja/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository